### PR TITLE
Disable next auth's "Refetch On Window Focus" option

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,7 +23,7 @@ function MyApp({
   const getLayout = Component.getLayout ?? ((page) => page)
 
   return (
-    <SessionProvider session={session}>
+    <SessionProvider session={session} refetchOnWindowFocus={false}>
       <ThemeProvider attribute="class" disableTransitionOnChange>
         {Component.auth ? (
           <Auth>{getLayout(<Component {...pageProps} />)}</Auth>


### PR DESCRIPTION
@jasonlong reported in #21 that sometimes safari on iOS would redirect to an error page.

After some investigations I've found that it's related to refetching next-auth's session when the tab gains focus again. 

The solution for now is to temporarily disable this feature in next-auth.