### PR TITLE
Update pagination labels

### DIFF
--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -80,6 +80,26 @@ export function MessageIcon(props: IconProps) {
   )
 }
 
+export function ChevronLeftIcon(props: IconProps) {
+  return (
+    <svg
+      width={16}
+      height={16}
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M9.5 4.5L6.35355 7.64645C6.15829 7.84171 6.15829 8.15829 6.35355 8.35355L9.5 11.5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
 export function ChevronRightIcon(props: IconProps) {
   return (
     <svg

--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -1,5 +1,5 @@
 import { ButtonLink } from '@/components/button-link'
-import { ChevronRightIcon } from '@/components/icons'
+import { ChevronLeftIcon, ChevronRightIcon } from '@/components/icons'
 import { useRouter } from 'next/router'
 
 type PaginationProps = {
@@ -46,8 +46,8 @@ export function Pagination({
           currentPageNumber === 1 ? 'pointer-events-none opacity-50' : ''
         }
       >
-        <span className="mr-1 rotate-180">
-          <ChevronRightIcon />
+        <span className="mr-1">
+          <ChevronLeftIcon />
         </span>
         Newer posts
       </ButtonLink>


### PR DESCRIPTION
This updates the pagination buttons to use clearer labels. I found it confusing to click <kbd>Next</kbd> to see older (aka. previous) posts and <kbd>Previous</kbd> to see newer posts.

### Before

<img width="226" alt="CleanShot 2022-02-17 at 19 14 35@2x" src="https://user-images.githubusercontent.com/6104/154593279-10154714-0243-484f-8141-e1303fd6167c.png">


### After

<img width="333" alt="CleanShot 2022-02-17 at 17 00 05@2x" src="https://user-images.githubusercontent.com/6104/154593182-eda3d4cf-310f-4a7e-9a28-95038253d0ab.png">

