### PR TITLE
Remove prettier-plugin-organize-imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "husky": "^7.0.0",
         "postcss": "^8.4.6",
         "prettier": "2.5.1",
-        "prettier-plugin-organize-imports": "^2.3.4",
         "pretty-quick": "^3.1.3",
         "prisma": "^3.9.1",
         "tailwindcss": "^3.0.18",
@@ -4636,16 +4635,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/prettier-plugin-organize-imports": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.4.tgz",
-      "integrity": "sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==",
-      "dev": true,
-      "peerDependencies": {
-        "prettier": ">=2.0",
-        "typescript": ">=2.9"
-      }
-    },
     "node_modules/pretty-format": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
@@ -9210,13 +9199,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
-    },
-    "prettier-plugin-organize-imports": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-2.3.4.tgz",
-      "integrity": "sha512-R8o23sf5iVL/U71h9SFUdhdOEPsi3nm42FD/oDYIZ2PQa4TNWWuWecxln6jlIQzpZTDMUeO1NicJP6lLn2TtRw==",
-      "dev": true,
-      "requires": {}
     },
     "pretty-format": {
       "version": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "husky": "^7.0.0",
     "postcss": "^8.4.6",
     "prettier": "2.5.1",
-    "prettier-plugin-organize-imports": "^2.3.4",
     "pretty-quick": "^3.1.3",
     "prisma": "^3.9.1",
     "tailwindcss": "^3.0.18",


### PR DESCRIPTION
`prettier-plugin-organize-imports` can't be configured to disable removing unused imports, so for now let's remove it and add https://www.npmjs.com/package/eslint-plugin-import later as @jasonlong [suggested](https://github.com/planetscale/beam/issues/37#issuecomment-1045085278) 

Fixes #37 