### PR TITLE
Add GitHub org authorization access note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) in your browser.
 
+### Authenticating with GitHub
+
+If you're using a GitHub OAuth app for authentication, you'll need to Request (if you're an organization member) or Grant (if you're an organization owner) access to the organization specified in `GITHUB_ALLOWED_ORG` on the GitHub authorization screen. Failure to provide access to the organization will result in an "Access Denied" error screen with the message "You do not have permission to sign in."
+
+![Github app authorization organizations list](https://user-images.githubusercontent.com/1954752/155861462-924247cc-545c-4654-aec6-a30940a38882.png)
+
 ## Deploying to Vercel
 
 One-click deploy:


### PR DESCRIPTION
Hi yall 👋 

Thanks for all the work you've put into creating `beam`! It seems like a nice, lightweight solution to facilitate communication and I'm excited to try it out!

When setting up a test instance, one issue that took me awhile to resolve was that you have to Request or Grant access to the org specified in `GITHUB_ALLOWED_ORG` on the GitHub authorization screen. It's quite easy to skip this and just grant access to your own user account if you're not thinking about it and there's no error specific to this situation to let you know what's wrong.

This PR adds a note to the `README` about this situation. It probably makes more sense to have a specific error screen for this, but that's more effort than a little bit of Markdown 😁 