### PR TITLE
Make NEXT_APP_URL an Optional ENV variable

### DIFF
--- a/env/server.ts
+++ b/env/server.ts
@@ -46,7 +46,7 @@ export const serverEnv = {
   ...browserEnv,
   ...envsafe({
     DATABASE_URL: str(),
-    NEXT_APP_URL: url({
+    NEXT_APP_URL: slackParser({
       allowEmpty: true,
       devDefault: 'http://localhost:3000',
     }),

--- a/env/server.ts
+++ b/env/server.ts
@@ -47,6 +47,7 @@ export const serverEnv = {
   ...envsafe({
     DATABASE_URL: str(),
     NEXT_APP_URL: url({
+      allowEmpty: true,
       devDefault: 'http://localhost:3000',
     }),
     NEXTAUTH_SECRET: str({


### PR DESCRIPTION
This makes the NEXT_APP_URL env variable optional so you can deploy without errors if slack integration is turned off, but leaves the URL Type safety in place.

Another option would be to use the slackParser function to validate, but since it only validates the string you would lose URL Type safety which ensures the env var is a url with a protocol and hostname.

Resolves #57 