### PR TITLE
Clear floated elements

### DIFF
--- a/components/post-summary.tsx
+++ b/components/post-summary.tsx
@@ -90,7 +90,7 @@ export function PostSummary({
 
         <HtmlView html={summary} className={hideAuthor ? 'mt-4' : 'mt-6'} />
 
-        <div className="flex items-center gap-4 mt-4">
+        <div className="flex items-center gap-4 mt-4 clear-both">
           {hasMoreContent && (
             <Link href={`/post/${post.id}`}>
               <a className="inline-flex items-center font-medium transition-colors text-blue">

--- a/pages/post/[id]/index.tsx
+++ b/pages/post/[id]/index.tsx
@@ -240,7 +240,7 @@ const PostPage: NextPageWithAuthAndLayout = () => {
               />
             </div>
             <HtmlView html={postQuery.data.contentHtml} className="mt-8" />
-            <div className="flex gap-4 mt-6">
+            <div className="flex gap-4 mt-6 clear-both">
               <LikeButton
                 likedBy={postQuery.data.likedBy}
                 onLike={() => {


### PR DESCRIPTION
If someone manually updates an `<img>` tag to float it (which looks nice on the post page), it'll break the layout on the index and profile pages. This clears the floats before showing the next container.