### PR TITLE
Provide a programmatic / API driven way to create PlanetScale DB and connection string

### DIFF
--- a/.github/workflows/create-database.yml
+++ b/.github/workflows/create-database.yml
@@ -1,0 +1,25 @@
+name: Create PlanetScale Database
+
+on: workflow_dispatch
+
+env:
+  pscale_base_directory: .pscale
+
+jobs:
+  create-database:
+    name: 'Create database - click here'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Create database - please click on displayed link to authenticate
+        timeout-minutes: 3
+        env:
+          PLANETSCALE_SERVICE_TOKEN_ID: ${{secrets.PLANETSCALE_SERVICE_TOKEN_ID}}
+          ORG_NAME: ${{secrets.ORG_NAME}}
+          DB_NAME: ${{secrets.DB_NAME}}
+          GITHUB_USER: ${{github.actor}}
+        working-directory: ${{env.pscale_base_directory}}/cli-helper-scripts/
+        run: ./create-database.sh

--- a/.pscale/cli-helper-scripts/authenticate-ps.sh
+++ b/.pscale/cli-helper-scripts/authenticate-ps.sh
@@ -1,0 +1,10 @@
+# if PLANETSCALE_SERVICE_TOKEN is not set, use pscale auth login
+if [ -z "$PLANETSCALE_SERVICE_TOKEN" ]; then
+    echo "Going to authenticate PlanetScale CLI, please follow the link displayed in your browser and confirm ..."
+    pscale auth login
+    # if command failed, exit
+    if [ $? -ne 0 ]; then
+        echo "pscale auth login failed, please try again"
+        exit 1
+    fi
+fi

--- a/.pscale/cli-helper-scripts/create-branch-connection-string.sh
+++ b/.pscale/cli-helper-scripts/create-branch-connection-string.sh
@@ -1,0 +1,59 @@
+function create-branch-connection-string {
+    local DB_NAME=$1
+    local BRANCH_NAME=$2
+    local ORG_NAME=$3
+    local CREDS=${4,,}
+    local secretshare=$5
+
+    # delete password if it already existed
+    # first, list password if it exists
+    local raw_output=`pscale password list "$DB_NAME" "$BRANCH_NAME" --org "$ORG_NAME" --format json `
+    # check return code, if not 0 then error
+    if [ $? -ne 0 ]; then
+        echo "Error: pscale password list returned non-zero exit code $?: $raw_output"
+        exit 1
+    fi
+
+    local output=`echo $raw_output | jq -r "[.[] | select(.display_name == \"$CREDS\") ] | .[0].id "`
+    # if output is not "null", then password exists, delete it
+    if [ "$output" != "null" ]; then
+        echo "Deleting existing password $output"
+        pscale password delete --force "$DB_NAME" "$BRANCH_NAME" "$output" --org "$ORG_NAME"
+        # check return code, if not 0 then error
+        if [ $? -ne 0 ]; then
+            echo "Error: pscale password delete returned non-zero exit code $?"
+            exit 1
+        fi
+    fi
+    
+    local raw_output=`pscale password create "$DB_NAME" "$BRANCH_NAME" "$CREDS" --org "$ORG_NAME" --format json`
+    
+    if [ $? -ne 0 ]; then
+        echo "Failed to create credentials for database $DB_NAME branch $BRANCH_NAME: $raw_output"
+        exit 1
+    fi
+
+    local DB_URL=`echo "$raw_output" |  jq -r ". | \"mysql://\" + .id +  \":\" + .plain_text +  \"@\" + .database_branch.access_host_url + \"/\""`
+
+read -r -d '' SECRET_TEXT <<EOF
+DATABASE_URL=${DB_URL}/${DB_NAME}?sslaccept=strict
+EOF
+
+    # if not running in CI
+    if [ -z "$CI" ]; then
+        echo "Please copy file .env.example to .env and set the value of DATABASE_URL to your newly created PlanetScale database like this:" 
+        echo "$SECRET_TEXT"
+    elif [ -n "$secretshare" ]; then
+        # store the DB URL in secret store
+        echo "::notice ::Please follow the link in the next line and click on 'Read the Secret!' to see the secret, branch specific connection string for various frameworks."
+        local link=`curl -s -X POST -d "plain&secret=$SECRET_TEXT" https://shared-secrets-planetscale.herokuapp.com/`
+        echo "$link"
+        echo "::set-output name=CONNECTION_STRING_LINK::${link}"
+    fi
+    echo
+    echo "Alternatively, you can connect to your new branch like this:"
+    echo "pscale shell \"$DB_NAME\" \"$BRANCH_NAME\" --org \"$ORG_NAME\""
+    echo "or, to create a local tunnel to the database:"
+    echo "pscale connect \"$DB_NAME\" \"$BRANCH_NAME\" --org \"$ORG_NAME\""
+    export MY_DB_URL=$DB_URL
+}

--- a/.pscale/cli-helper-scripts/create-database.sh
+++ b/.pscale/cli-helper-scripts/create-database.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+BRANCH_NAME=${BRANCH_NAME:-"main"}
+
+. use-pscale-docker-image.sh
+
+# At the moment, service tokens do not allow DB creations or prod branch promotions, hence not using the service token.
+unset PLANETSCALE_SERVICE_TOKEN
+. authenticate-ps.sh
+
+. set-db-and-org-and-branch-name.sh
+. wait-for-branch-readiness.sh
+
+pscale database create "$DB_NAME" --region us-east --org "$ORG_NAME"
+# check if DB creation worked
+if [ $? -ne 0 ]; then
+  echo "Failed to create database $DB_NAME"
+  exit 1
+fi
+
+# If BRANCH_NAME was not set to main, we need to create the branch
+if [ "$BRANCH_NAME" != "main" ]; then
+  pscale branch create "$BRANCH_NAME" --org "$ORG_NAME"
+  if [ $? -ne 0 ]; then
+    echo "Failed to create branch $BRANCH_NAME"
+    exit 1
+  fi
+fi
+
+wait_for_branch_readiness 10 "$DB_NAME" "$BRANCH_NAME" "$ORG_NAME" 30
+
+# grant service token permission to use the database if service token is set
+if [ -n "$PLANETSCALE_SERVICE_TOKEN_ID" ]; then
+  echo "Granting access to new database for service tokens ..."
+  pscale service-token add-access "$PLANETSCALE_SERVICE_TOKEN_ID" approve_deploy_request connect_branch create_branch create_comment create_deploy_request delete_branch read_branch read_deploy_request connect_production_branch  --database "$DB_NAME" --org "$ORG_NAME"
+fi
+
+. create-branch-connection-string.sh
+
+create-branch-connection-string  "$DB_NAME" "$BRANCH_NAME" "$ORG_NAME" "creds-${BRANCH_NAME}" "share"

--- a/.pscale/cli-helper-scripts/create-db-branch-dr-and-connection.sh
+++ b/.pscale/cli-helper-scripts/create-db-branch-dr-and-connection.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+. use-pscale-docker-image.sh
+. wait-for-branch-readiness.sh
+
+. authenticate-ps.sh
+
+BRANCH_NAME="$1"
+DDL_STATEMENTS="$2" 
+
+. set-db-and-org-and-branch-name.sh
+
+. ps-create-helper-functions.sh
+create-db-branch "$DB_NAME" "$BRANCH_NAME" "$ORG_NAME" "recreate"
+create-schema-change "$DB_NAME" "$BRANCH_NAME" "$ORG_NAME" "$DDL_STATEMENTS"
+create-deploy-request "$DB_NAME" "$BRANCH_NAME" "$ORG_NAME"
+
+
+. create-branch-connection-string.sh
+create-branch-connection-string "$DB_NAME" "$BRANCH_NAME" "$ORG_NAME" "creds-${BRANCH_NAME}" "sharesecret"

--- a/.pscale/cli-helper-scripts/ps-create-helper-functions.sh
+++ b/.pscale/cli-helper-scripts/ps-create-helper-functions.sh
@@ -1,0 +1,226 @@
+function create-db-branch {
+    local DB_NAME=$1
+    local BRANCH_NAME=$2
+    local ORG_NAME=$3
+    local recreate_branch=$4
+
+    # delete the branch if it already exists and recreate branch is set
+    if [ -n "$recreate_branch" ]; then
+        echo "Trying to delete branch $BRANCH_NAME if it already existed ..."
+        pscale branch delete "$DB_NAME" "$BRANCH_NAME" --force --org "$ORG_NAME" 2>/dev/null
+    fi
+
+    pscale branch create "$DB_NAME" "$BRANCH_NAME" --region us-east --org "$ORG_NAME"
+    # if branch creation fails, exit with error
+    if [ $? -ne 0 ]; then
+        echo "Failed to create branch $BRANCH_NAME for database $DB_NAME"
+        exit 1
+    fi
+
+    wait_for_branch_readiness 10 "$DB_NAME" "$BRANCH_NAME" "$ORG_NAME" 20
+    if [ $? -ne 0 ]; then
+        echo "Branch $BRANCH_NAME is not ready"
+        exit 1
+    fi
+
+    local branch_url="https://app.planetscale.com/${ORG_NAME}/${DB_NAME}/${BRANCH_NAME}"
+    echo "Branch $BRANCH_NAME is ready at $branch_url"
+    # if CI variable ist set, then set output variables
+    if [ -n "$CI" ]; then
+        echo "::set-output name=BRANCH_URL::$branch_url"
+    fi
+}
+
+function create-schema-change {
+    local DB_NAME=$1
+    local BRANCH_NAME=$2
+    local ORG_NAME=$3
+    local DDL_STATEMENTS=$4
+
+    echo "Changing schema with the following DDL statements:"
+    echo $DDL_STATEMENTS
+    echo "$DDL_STATEMENTS" | pscale shell "$DB_NAME" "$BRANCH_NAME" --org "$ORG_NAME"
+    if [ $? -ne 0 ]; then
+        echo "Schema change in $BRANCH_NAME could not be created"
+        exit 1
+    fi
+}
+
+
+function create-deploy-request {
+    local DB_NAME=$1
+    local BRANCH_NAME=$2
+    local ORG_NAME=$3
+
+    local raw_output=`pscale deploy-request create "$DB_NAME" "$BRANCH_NAME" --org "$ORG_NAME" --format json`
+    if [ $? -ne 0 ]; then
+        echo "Deploy request could not be created: $raw_output"
+        exit 1
+    fi
+    local deploy_request_number=`echo $raw_output | jq -r '.number'`
+    # if deploy request number is empty, then error
+    if [ -z "$deploy_request_number" ]; then
+        echo "Could not retrieve deploy request number: $raw_output"
+        exit 1
+    fi
+
+    local deploy_request="https://app.planetscale.com/${ORG_NAME}/${DB_NAME}/deploy-requests/${deploy_request_number}"
+    echo "Check out the deploy request created at $deploy_request"
+    # if CI variable is set, export the deploy request URL
+    if [ -n "$CI" ]; then
+        echo "::set-output name=DEPLOY_REQUEST_URL::$deploy_request"
+        echo "::set-output name=DEPLOY_REQUEST_NUMBER::$deploy_request_number"
+        create-diff-for-ci "$DB_NAME" "$ORG_NAME" "$deploy_request_number" "$BRANCH_NAME"
+    fi   
+}
+
+function create-deploy-request-info {
+    local DB_NAME=$1
+    local ORG_NAME=$2
+    local DEPLOY_REQUEST_NUMBER=$3
+
+    local raw_output=`pscale deploy-request show "$DB_NAME" "$DEPLOY_REQUEST_NUMBER" --org "$ORG_NAME" --format json`
+    if [ $? -ne 0 ]; then
+        echo "Deploy request could not be retrieved: $raw_output"
+        exit 1
+    fi
+    # extract the branch name from the deploy request
+    local branch_name=`echo $raw_output | jq -r '.branch'`
+
+    # check if the branch name is empty
+    if [ -z "$branch_name" ]; then
+        echo "Could not extract branch name from deploy request $DEPLOY_REQUEST_NUMBER"
+        exit 1
+    fi
+
+    export BRANCH_NAME="$branch_name"
+    local deploy_request="https://app.planetscale.com/${ORG_NAME}/${DB_NAME}/deploy-requests/${DEPLOY_REQUEST_NUMBER}"
+
+    local branch_url="https://app.planetscale.com/${ORG_NAME}/${DB_NAME}/${BRANCH_NAME}"
+    export BRANCH_URL="$branch_url"
+
+    # if CI variable is set, export deployment request info
+    if [ -n "$CI" ]; then
+        echo "::set-output name=BRANCH_NAME::$branch_name"
+        echo "::set-output name=DB_NAME::$DB_NAME"
+        echo "::set-output name=ORG_NAME::$ORG_NAME"
+        echo "::set-output name=DEPLOY_REQUEST_URL::$deploy_request"
+        echo "::set-output name=DEPLOY_REQUEST_NUMBER::$DEPLOY_REQUEST_NUMBER"
+        echo "::set-output name=BRANCH_URL::$branch_url"
+    fi
+}
+
+function create-branch-info {
+    local DB_NAME=$1
+    local BRANCH_NAME=$2
+    local ORG_NAME=$3
+
+    local raw_output=`pscale branch show "$DB_NAME" "$BRANCH_NAME" --org "$ORG_NAME" --format json`
+    if [ $? -ne 0 ]; then
+        echo "Branch could not be retrieved: $raw_output"
+        exit 1
+    fi
+    # extract the branch name from the deploy request
+    local branch_name=`echo $raw_output | jq -r '.name'`
+
+    # check if the branch name is empty
+    if [ -z "$branch_name" ]; then
+        echo "Could not extract existing branch name from branch $BRANCH_NAME"
+        exit 1
+    fi
+
+    export BRANCH_NAME="$branch_name"
+    
+    local branch_url="https://app.planetscale.com/${ORG_NAME}/${DB_NAME}/${BRANCH_NAME}"
+    export BRANCH_URL="$branch_url"
+
+    # if CI variable is set, export branch info
+    if [ -n "$CI" ]; then
+        echo "::set-output name=BRANCH_NAME::$branch_name"
+        echo "::set-output name=DB_NAME::$DB_NAME"
+        echo "::set-output name=ORG_NAME::$ORG_NAME"
+        echo "::set-output name=BRANCH_URL::$branch_url"
+    fi
+}
+
+function create-diff-for-ci {
+    local DB_NAME=$1
+    local ORG_NAME=$2
+    local deploy_request_number=$3 
+    local BRANCH_NAME=$4
+    local refresh_schema=$5
+
+    local deploy_request="https://app.planetscale.com/${ORG_NAME}/${DB_NAME}/deploy-requests/${deploy_request_number}"
+    local BRANCH_DIFF="Diff could not be generated for deploy request $deploy_request"
+
+    # updating schema for branch
+    if [ -n "$refresh_schema" ]; then
+        pscale branch refresh-schema "$DB_NAME" "$BRANCH_NAME" --org "$ORG_NAME"
+    fi  
+
+    local lines=""
+    # read shell output line by line and assign to variable
+    while read -r line; do
+        lines="$lines\n$line"
+    done < <(pscale deploy-request diff "$DB_NAME" "$deploy_request_number" --org "$ORG_NAME" --format=json | jq .[].raw)
+
+    
+    if [ $? -ne 0 ]; then
+        BRANCH_DIFF="$BRANCH_DIFF : ${lines}"
+    else
+        BRANCH_DIFF=$lines
+    fi
+
+    if [ -n "$CI" ]; then
+        BRANCH_DIFF="${BRANCH_DIFF//'"'/''}"
+        BRANCH_DIFF="${BRANCH_DIFF//'%'/'%25'}"
+        BRANCH_DIFF="${BRANCH_DIFF//'\n'/'%0A'}"
+        BRANCH_DIFF="${BRANCH_DIFF//'\r'/'%0D'}"
+        echo "::set-output name=BRANCH_DIFF::$BRANCH_DIFF"
+    fi
+}
+
+function create-deployment {
+    local DB_NAME=$1
+    local ORG_NAME=$2
+    local deploy_request_number=$3
+
+    local deploy_request="https://app.planetscale.com/${ORG_NAME}/${DB_NAME}/deploy-requests/${deploy_request_number}"
+    # if CI variable is set, export the deploy request parameters
+    if [ -n "$CI" ]; then
+        echo "::set-output name=DEPLOY_REQUEST_URL::$deploy_request"
+        echo "::set-output name=DEPLOY_REQUEST_NUMBER::$deploy_request_number"
+    fi
+
+    echo "Going to deploy deployment request $deploy_request with the following changes: "
+
+    pscale deploy-request diff "$DB_NAME" "$deploy_request_number" --org "$ORG_NAME"
+    # only ask for user input if CI variabe is not set
+    if [ -z "$CI" ]; then
+        read -p "Do you want to deploy this deployment request? [y/N] " -n 1 -r
+        echo
+        if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+            echo "Deployment request $deploy_request_number was not deployed."
+            exit 1
+        fi
+    else
+        create-diff-for-ci "$DB_NAME" "$ORG_NAME" "$deploy_request_number" "$BRANCH_NAME"
+    fi
+
+    pscale deploy-request deploy "$DB_NAME" "$deploy_request_number" --org "$ORG_NAME"
+    # check return code, if not 0 then error
+    if [ $? -ne 0 ]; then
+        echo "Error: pscale deploy-request deploy returned non-zero exit code"
+        exit 1
+    fi
+
+    wait_for_deploy_request_merged 9 "$DB_NAME" "$deploy_request_number" "$ORG_NAME" 60
+    if [ $? -ne 0 ]; then
+        echo "Error: wait-for-deploy-request-merged returned non-zero exit code"
+        echo "Check out the deploy request status at $deploy_request"
+        exit 5
+    else
+        echo "Check out the deploy request at $deploy_request"
+    fi
+
+}

--- a/.pscale/cli-helper-scripts/set-db-and-org-and-branch-name.sh
+++ b/.pscale/cli-helper-scripts/set-db-and-org-and-branch-name.sh
@@ -1,0 +1,30 @@
+
+# Set DB_NAME unless it is already set
+export DB_NAME=${DB_NAME:-beam-${GITHUB_USER:-db}}
+echo "Using DB name ${DB_NAME}"
+
+# set org name to first org the user has access to unless it is already set in ORG_NAME
+if [ -z "${ORG_NAME}" ]; then
+    export ORG_NAME=`pscale org list --format json | jq -r ".[0].name"`
+    # check exit code
+    if [ $? -ne 0 ] || [ -z "${ORG_NAME}" ]; then
+        echo "Error: Failed to get PlanetScale org name, please set ORG_NAME explicitly or use Web based SSO, service tokens do not allow to list orgs."
+        exit 1
+    fi
+    # if org name is set to planetscale, we will set org name to planetscale-demo instead
+    if [ "${ORG_NAME}" = "planetscale" ]; then
+        export ORG_NAME="planetscale-demo"
+    fi
+fi
+
+echo "Using org name ${ORG_NAME}"
+
+export BRANCH_NAME=${BRANCH_NAME:-"main"}
+echo "Using branch name ${BRANCH_NAME}"
+
+# if CI variable ist set
+if [ -n "$CI" ]; then
+    echo "::set-output name=DB_NAME::$DB_NAME"
+    echo "::set-output name=ORG_NAME::$ORG_NAME"
+    echo "::set-output name=BRANCH_NAME::$BRANCH_NAME"
+fi

--- a/.pscale/cli-helper-scripts/use-pscale-docker-image.sh
+++ b/.pscale/cli-helper-scripts/use-pscale-docker-image.sh
@@ -1,0 +1,37 @@
+echo Using pscale CLI from latest docker image ...
+mkdir -p $HOME/.config/planetscale
+
+function pscale {
+    local tty="-t"
+    local non_interactive=""
+    local command=""
+    
+    # if first arg equals shell, and we are getting input piped in we have to turn off pseudo-tty and set PSCALE_ALLOW_NONINTERACTIVE_SHELL=true
+    if [ "$1" = "shell" ] &&  ! [[ -t 0 ]]; then
+        tty=""
+        non_interactive="-e PSCALE_ALLOW_NONINTERACTIVE_SHELL=true"
+    fi
+
+    # if script is run in CI and it is not the auth command, we have to turn off pseudo-tty
+    if [ -n "$CI" ] && [ "$1" != "auth" ]; then
+        tty=""
+    fi
+
+    # if NO_DOCKER is set, we will use the locally installed version of pscale
+    if [ -n "$NO_DOCKER" ]; then
+        command="`which pscale` $@"
+    else
+        # For debugging, set PSCALE_VERSION to a version of your choice. It defaults to "latest".
+        command="docker run -e PLANETSCALE_SERVICE_TOKEN=${PLANETSCALE_SERVICE_TOKEN:-""} -e PLANETSCALE_SERVICE_TOKEN_ID=$PLANETSCALE_SERVICE_TOKEN_ID -e PLANETSCALE_SERVICE_TOKEN_NAME=$PLANETSCALE_SERVICE_TOKEN_NAME -e HOME=/tmp -v $HOME/.config/planetscale:/tmp/.config/planetscale -e PSCALE_ALLOW_NONINTERACTIVE_SHELL=true --user $(id -u):$(id -g) --rm -i $tty planetscale/pscale:${PSCALE_VERSION:-"latest"} $@"
+    fi
+
+    # if command is auth and we are running in CI, we will use the script command to get a fake terminal
+    if [ "$1" = "auth" ] && [ -n "$CI" ]; then
+        echo "::notice ::Please visit the URL displayed in the line below in your browser to authenticate"
+        command="script -q -f --return -c '$command' | perl -ne '\$| = 1; \$/ = \"\r\"; \$counter=0; while (<>) { \$url = \$1 if /(http.*)$/; print \"Please click on \" . \$url . \"\n\" if \$url && (\$counter++)%100==0; }'"
+        eval $command
+    else
+        $command
+    fi
+    
+}

--- a/.pscale/cli-helper-scripts/wait-for-branch-readiness.sh
+++ b/.pscale/cli-helper-scripts/wait-for-branch-readiness.sh
@@ -1,0 +1,50 @@
+function wait_for_branch_readiness {
+    local retries=$1
+    local db=$2
+    local branch=${3,,}
+    local org=$4
+    
+    # check whether fifth parameter is set, otherwise use default value
+    if [ -z "$5" ]; then
+        local max_timeout=60
+    else
+        local max_timeout=$5
+    fi
+
+    local count=0
+    local wait=1
+
+    echo "Checking if branch $branch is ready for use..."
+    while true; do
+        local raw_output=`pscale branch list $db --org $org --format json`
+        # check return code, if not 0 then error
+        if [ $? -ne 0 ]; then
+            echo "Error: pscale branch list returned non-zero exit code $?: $raw_output"
+            return 1
+        fi
+        local output=`echo $raw_output | jq ".[] | select(.name == \"$branch\") | .ready"`
+        # test whether output is false, if so, increase wait timeout exponentially
+        if [ "$output" == "false" ]; then
+            # increase wait variable exponentially but only if it is less than max_timeout
+            if [ $((wait * 2)) -le $max_timeout ]; then
+                wait=$((wait * 2))
+            else
+                wait=$max_timeout
+            fi  
+
+            count=$((count+1))
+            if [ $count -ge $retries ]; then
+                echo "Branch $branch is not ready after $retries retries. Exiting..."
+                return 2
+            fi
+            echo "Branch $branch is not ready yet. Retrying in $wait seconds..."
+            sleep $wait
+        elif [ "$output" == "true" ]; then
+            echo "Branch $branch is ready for use."
+            return 0
+        else
+            echo "Branch $branch in unknown status: $raw_output"
+            return 3
+        fi
+    done
+}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cd .pscale/cli-helper-scripts/
 
 or
 
-![image](https://user-images.githubusercontent.com/1872314/173367645-2627d5de-5635-43ec-8adf-60b9508c562f.png)
+![image](https://user-images.githubusercontent.com/1872314/174285290-a479b5c7-55fa-4d2f-bc67-186379d66c69.png)
 
 - Set up the environment variables:
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ npm install
 
 - [Create a PlanetScale database](https://docs.planetscale.com/tutorials/planetscale-quick-start-guide#create-a-database)
 - Create a [connection string](https://docs.planetscale.com/concepts/connection-strings#creating-a-password) to connect to your database. Choose **Prisma** for the format
+- Alternatively, create your PlanetScale database and connection string programmatically, either with a script using [pscale CLI](https://github.com/planetscale/cli) or by running a GitHub Action wokflow:
+
+```bash
+cd .pscale/cli-helper-scripts/
+./create-database.sh
+```
+
+or
+
+![image](https://user-images.githubusercontent.com/1872314/173367645-2627d5de-5635-43ec-8adf-60b9508c562f.png)
+
 - Set up the environment variables:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install
 
 - [Create a PlanetScale database](https://docs.planetscale.com/tutorials/planetscale-quick-start-guide#create-a-database)
 - Create a [connection string](https://docs.planetscale.com/concepts/connection-strings#creating-a-password) to connect to your database. Choose **Prisma** for the format
-- Alternatively, create your PlanetScale database and connection string programmatically, either with a script using [pscale CLI](https://github.com/planetscale/cli) or by running a GitHub Action wokflow:
+- Alternatively, create your PlanetScale database and connection string programmatically, either with a script using [pscale CLI](https://github.com/planetscale/cli) or by running a GitHub Action workflow:
 
 ```bash
 cd .pscale/cli-helper-scripts/


### PR DESCRIPTION
So far, beam's README describes the steps to manually [create a PlanetScale database](https://docs.planetscale.com/tutorials/planetscale-quick-start-guide#create-a-database) and [connection string](https://docs.planetscale.com/concepts/connection-strings#creating-a-password).

This PR contributes
*  scripts to create a database and connection string using the [pscale CLI](https://github.com/planetscale/cli) including instructions on how to set the Prisma connection string properly
*  a GitHub Action workflow that can be run from GitHub to create the database and connection string using Web based authentication
![image](https://user-images.githubusercontent.com/1872314/174285290-a479b5c7-55fa-4d2f-bc67-186379d66c69.png)

* a description in the README file how to use the scripts or the Action workflow