### PR TITLE
Move pscale/actions setup to its own file

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,7 @@ npm install
 
 - [Create a PlanetScale database](https://docs.planetscale.com/tutorials/planetscale-quick-start-guide#create-a-database)
 - Create a [connection string](https://docs.planetscale.com/concepts/connection-strings#creating-a-password) to connect to your database. Choose **Prisma** for the format
-- Alternatively, create your PlanetScale database and connection string programmatically, either with a script using [pscale CLI](https://github.com/planetscale/cli) or by running a GitHub Action workflow:
-
-```bash
-cd .pscale/cli-helper-scripts/
-./create-database.sh
-```
-
-or
-
-![image](https://user-images.githubusercontent.com/1872314/174285290-a479b5c7-55fa-4d2f-bc67-186379d66c69.png)
-
+- **Alternatively**, your PlanetScale database and connection string can be generated using the [pscale CLI](https://github.com/planetscale/cli) or GitHub Actions. [View instructions](doc/pscale-actions-setup.md).
 - Set up the environment variables:
 
 ```bash

--- a/doc/pscale-actions-setup.md
+++ b/doc/pscale-actions-setup.md
@@ -1,0 +1,10 @@
+### Create a database with pscale
+
+```bash
+cd .pscale/cli-helper-scripts/
+./create-database.sh
+```
+
+### Create a database with the GitHub Actions workflow
+
+![image](https://user-images.githubusercontent.com/1872314/174285290-a479b5c7-55fa-4d2f-bc67-186379d66c69.png)


### PR DESCRIPTION
This moves @jonico's new `pscale` and Actions instructions (#65) to their own doc file to streamline the top-level README.