### PR TITLE
Upgrade textarea-markdown-editor to v1.0.1

### DIFF
--- a/components/markdown-editor.tsx
+++ b/components/markdown-editor.tsx
@@ -4,7 +4,7 @@ import { browserEnv } from '@/env/browser'
 import { classNames } from '@/lib/classnames'
 import {
   getSuggestionData,
-  handleUploadImages,
+  uploadImageCommandHandler,
   markdownToHtml,
 } from '@/lib/editor'
 import { trpc } from '@/lib/trpc'
@@ -209,15 +209,7 @@ export function MarkdownEditor({
         </div>
 
         <div className={classNames('mt-2 relative', showPreview && 'sr-only')}>
-          <TextareaMarkdown.Wrapper
-            ref={textareaMarkdownRef}
-            commands={[
-              {
-                name: 'indent',
-                enable: false,
-              },
-            ]}
-          >
+          <TextareaMarkdown.Wrapper ref={textareaMarkdownRef}>
             <TextareaAutosize
               {...rest}
               value={value}
@@ -279,7 +271,7 @@ export function MarkdownEditor({
 
                   event.preventDefault()
 
-                  handleUploadImages(event.currentTarget, imageFiles)
+                  uploadImageCommandHandler(event.currentTarget, imageFiles)
                 }
               }}
               onDrop={(event) => {
@@ -300,7 +292,7 @@ export function MarkdownEditor({
 
                   event.preventDefault()
 
-                  handleUploadImages(event.currentTarget, imageFiles)
+                  uploadImageCommandHandler(event.currentTarget, imageFiles)
                 }
               }}
               className="block w-full rounded shadow-sm bg-secondary border-secondary focus-ring"

--- a/lib/editor.ts
+++ b/lib/editor.ts
@@ -13,22 +13,20 @@ function replacePlaceholder(
   placeholder: string,
   replaceWith: string
 ) {
-  cursor.setText(cursor.getText().replace(placeholder, replaceWith))
+  cursor.setValue(cursor.value.replace(placeholder, replaceWith))
 }
 
-export function handleUploadImages(
+export function uploadImageCommandHandler(
   textareaEl: HTMLTextAreaElement,
   files: File[]
 ) {
   const cursor = new Cursor(textareaEl)
-  const currentLineNumber = cursor.getCurrentPosition().lineNumber
+  const currentLineNumber = cursor.position.line
 
   files.forEach(async (file, idx) => {
     const placeholder = `![Uploading ${file.name}...]()`
 
-    cursor.spliceContent(Cursor.raw`${placeholder}${Cursor.$}`, {
-      startLineNumber: currentLineNumber + idx,
-    })
+    cursor.replaceLine(currentLineNumber.lineNumber, placeholder)
 
     try {
       const uploadedImage = await uploadImage(file)

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "react-textarea-autosize": "^8.3.3",
         "superjson": "^1.8.0",
         "textarea-caret": "^3.1.0",
-        "textarea-markdown-editor": "^0.1.13",
+        "textarea-markdown-editor": "^1.0.1",
         "use-debounce": "^7.0.1",
         "use-item-list": "^0.1.2",
         "zod": "^3.11.6"
@@ -5026,11 +5026,6 @@
         "react": "^16.8.0 || ^17.0.0"
       }
     },
-    "node_modules/react-trigger-change": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-trigger-change/-/react-trigger-change-1.0.2.tgz",
-      "integrity": "sha1-r1czmOzvJHU2K4T4wIwH/qI5FMM="
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -5552,16 +5547,15 @@
       "integrity": "sha512-cXAvzO9pP5CGa6NKx0WYHl+8CHKZs8byMkt3PCJBCmq2a34YA9pO1NrQET5pzeqnBjBdToF5No4rrmkDUgQC2Q=="
     },
     "node_modules/textarea-markdown-editor": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/textarea-markdown-editor/-/textarea-markdown-editor-0.1.13.tgz",
-      "integrity": "sha512-2r1gTPFA/wwAzt+Aa6LVZWjJNvL0aXfR6Z9T6eQBpJ1AK6gtPVCZgkO97KIrqpAmMcwgNCz0ToYj2AqPufdVeg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/textarea-markdown-editor/-/textarea-markdown-editor-1.0.1.tgz",
+      "integrity": "sha512-JFb2Y7sALJEVeCAFh2li1Otb/vHiXhXwaJcrbRU+NHhk5SfQcM0W9FwBZIux35TZTCv0L4bewJn9FxEB275nNQ==",
       "dependencies": {
-        "mousetrap": "^1.6.5",
-        "react-trigger-change": "^1.0.2"
+        "mousetrap": "^1.6.5"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17.0",
-        "react-dom": "^16.9.0 || ^17.0"
+        "react": "^16.8.0 || ^17.0.0 || || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/tiny-invariant": {
@@ -9510,11 +9504,6 @@
         "use-latest": "^1.0.0"
       }
     },
-    "react-trigger-change": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/react-trigger-change/-/react-trigger-change-1.0.2.tgz",
-      "integrity": "sha1-r1czmOzvJHU2K4T4wIwH/qI5FMM="
-    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -9879,12 +9868,11 @@
       "integrity": "sha512-cXAvzO9pP5CGa6NKx0WYHl+8CHKZs8byMkt3PCJBCmq2a34YA9pO1NrQET5pzeqnBjBdToF5No4rrmkDUgQC2Q=="
     },
     "textarea-markdown-editor": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/textarea-markdown-editor/-/textarea-markdown-editor-0.1.13.tgz",
-      "integrity": "sha512-2r1gTPFA/wwAzt+Aa6LVZWjJNvL0aXfR6Z9T6eQBpJ1AK6gtPVCZgkO97KIrqpAmMcwgNCz0ToYj2AqPufdVeg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/textarea-markdown-editor/-/textarea-markdown-editor-1.0.1.tgz",
+      "integrity": "sha512-JFb2Y7sALJEVeCAFh2li1Otb/vHiXhXwaJcrbRU+NHhk5SfQcM0W9FwBZIux35TZTCv0L4bewJn9FxEB275nNQ==",
       "requires": {
-        "mousetrap": "^1.6.5",
-        "react-trigger-change": "^1.0.2"
+        "mousetrap": "^1.6.5"
       }
     },
     "tiny-invariant": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@headlessui/react": "^1.4.3",
+    "@instantish/mack": "^1.2.0",
     "@next-auth/prisma-adapter": "^1.0.1",
     "@prisma/client": "^3.9.1",
     "@radix-ui/react-tooltip": "^0.1.6",
@@ -24,7 +25,6 @@
     "envsafe": "^2.0.3",
     "gemoji": "^7.1.0",
     "isomorphic-dompurify": "^0.18.0",
-    "@instantish/mack": "^1.2.0",
     "marked": "^4.0.12",
     "match-sorter": "^6.3.1",
     "next": "12.0.10",
@@ -41,7 +41,7 @@
     "react-textarea-autosize": "^8.3.3",
     "superjson": "^1.8.0",
     "textarea-caret": "^3.1.0",
-    "textarea-markdown-editor": "^0.1.13",
+    "textarea-markdown-editor": "^1.0.1",
     "use-debounce": "^7.0.1",
     "use-item-list": "^0.1.2",
     "zod": "^3.11.6"


### PR DESCRIPTION
In this PR I am upgrading the major version of the package `textarea-markdown-editor` to stable version 1.0.1, fixing breaking changes