### PR TITLE
Remove version in footer

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -27,7 +27,7 @@ export function Footer() {
         className="inline-flex items-center gap-2 text-sm transition-colors text-secondary hover:text-primary"
       >
         <GithubLogo className="w-4 h-4" />
-        <span>Version {packageJson.version}</span>
+        <span>View on GitHub</span>
       </a>
     </footer>
   )


### PR DESCRIPTION
We haven't ended up utilizing versions and releases, so let's not just show `1.0.0` in the footer forever.