### PR TITLE
Wrap the content of the post in an `<article>` to hint reader mode.

### DIFF
--- a/pages/post/[id]/index.tsx
+++ b/pages/post/[id]/index.tsx
@@ -139,7 +139,7 @@ const PostPage: NextPageWithAuthAndLayout = () => {
           <title>{postQuery.data.title} - Beam</title>
         </Head>
 
-        <div className="divide-y divide-primary">
+        <article className="divide-y divide-primary">
           <div className="pb-12">
             {postQuery.data.hidden && (
               <Banner className="mb-6">
@@ -284,7 +284,7 @@ const PostPage: NextPageWithAuthAndLayout = () => {
               <AddCommentForm postId={postQuery.data.id} />
             </div>
           </div>
-        </div>
+        </article>
 
         <ConfirmDeleteDialog
           postId={postQuery.data.id}


### PR DESCRIPTION
As far as I can tell, one of the main ways for browsers (Firefox for me) to detect that something can be viewed in "Reader" mode is by having articles wrapped in an `<article>` tag. I tried this and it appears to work:

![Screenshot 2023-03-28 at 6 36 37 PM](https://user-images.githubusercontent.com/1189716/228404100-dbfd033f-a4ef-407c-8cce-835dec86384b.png)

I love Firefox's reader view, because it helps me focus and read things faster, by using the screen-reader.

![Screenshot 2023-03-28 at 6 36 51 PM](https://user-images.githubusercontent.com/1189716/228404105-5f214368-1060-4418-b0ce-aba917066499.png)
