### PR TITLE
Fix sort buffer error on front page

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["referentialIntegrity", "fullTextSearch", "fullTextIndex"]
+  previewFeatures = ["referentialIntegrity", "fullTextSearch", "fullTextIndex", "extendedIndexes"]
 }
 
 datasource db {
@@ -87,6 +87,7 @@ model Post {
   comments    Comment[]
 
   @@index([authorId])
+  @@index([hidden, createdAt(sort: Desc)])
   @@fulltext([title, content])
 }
 


### PR DESCRIPTION
Adds an index that lets us avoid the sort buffer exhaustion seen in #58 when there's some particularly long content in `Post.contentHtml` fields.

From my test instance that reproduces the sort buffer error:

```sql
 explain SELECT Post.id,
    ->          Post.title,
    ->          Post.contentHtml,
    ->          Post.createdAt,
    ->          Post.hidden,
    ->          Post.authorId,
    ->          aggr_selection_0_Comment._aggr_count_comments
    -> FROM Post
    -> LEFT JOIN
    ->     (SELECT `Comment`.postId,
    ->          COUNT(*) AS _aggr_count_comments
    ->     FROM `Comment`
    ->     GROUP BY  `Comment`.postId) AS aggr_selection_0_Comment
    ->     ON Post.id = aggr_selection_0_Comment.postId
    -> WHERE Post.hidden = 0
    -> ORDER BY  beam.Post.createdAt DESC;
+----+-------------+------------+------------+-------+--------------------+--------------------+---------+--------------+------+----------+-----------------------------+
| id | select_type | table      | partitions | type  | possible_keys      | key                | key_len | ref          | rows | filtered | Extra                       |
+----+-------------+------------+------------+-------+--------------------+--------------------+---------+--------------+------+----------+-----------------------------+
|  1 | PRIMARY     | Post       | NULL       | ALL   | NULL               | NULL               | NULL    | NULL         |   16 |    10.00 | Using where; Using filesort |
|  1 | PRIMARY     | <derived2> | NULL       | ref   | <auto_key0>        | <auto_key0>        | 4       | beam.Post.id |    2 |   100.00 | NULL                        |
|  2 | DERIVED     | Comment    | NULL       | index | Comment_postId_idx | Comment_postId_idx | 4       | NULL         |    1 |   100.00 | Using index                 |
+----+-------------+------------+------------+-------+--------------------+--------------------+---------+--------------+------+----------+-----------------------------+
```


The schema diff when you perform this migration via PlanetScale deploy request:

```
-- The following SQL will run for this change
ALTER TABLE `Post` 
  ADD KEY `Post_hidden_createdAt_idx` (`hidden`, `createdAt` DESC)
```

With the index added we avoid the file sort and potential sort buffer exhaustion. Main page loads again.
```sql
+----+-------------+------------+------------+-------+---------------------------+---------------------------+---------+--------------+------+----------+-------------+
| id | select_type | table      | partitions | type  | possible_keys             | key                       | key_len | ref          | rows | filtered | Extra       |
+----+-------------+------------+------------+-------+---------------------------+---------------------------+---------+--------------+------+----------+-------------+
|  1 | PRIMARY     | Post       | NULL       | ref   | Post_hidden_createdAt_idx | Post_hidden_createdAt_idx | 1       | const        |   16 |   100.00 | NULL        |
|  1 | PRIMARY     | <derived2> | NULL       | ref   | <auto_key0>               | <auto_key0>               | 4       | beam.Post.id |    2 |   100.00 | NULL        |
|  2 | DERIVED     | Comment    | NULL       | index | Comment_postId_idx        | Comment_postId_idx        | 4       | NULL         |    1 |   100.00 | Using index |
+----+-------------+------------+------------+-------+---------------------------+---------------------------+---------+--------------+------+----------+-------------+
```
