### PR TITLE
Add a z-index to tooltips

### DIFF
--- a/components/like-button.tsx
+++ b/components/like-button.tsx
@@ -114,7 +114,7 @@ export function LikeButton({
         side="bottom"
         sideOffset={4}
         className={classNames(
-          'max-w-[260px] px-3 py-1.5 rounded shadow-lg bg-secondary-inverse text-secondary-inverse sm:max-w-sm',
+          'max-w-[260px] px-3 py-1.5 rounded shadow-lg bg-secondary-inverse text-secondary-inverse sm:max-w-sm z-10',
           likeCount === 0 && 'hidden'
         )}
       >

--- a/components/post-summary.tsx
+++ b/components/post-summary.tsx
@@ -107,7 +107,7 @@ export function PostSummary({
                 side="bottom"
                 sideOffset={4}
                 className={classNames(
-                  'max-w-[260px] px-3 py-1.5 rounded shadow-lg bg-secondary-inverse text-secondary-inverse sm:max-w-sm',
+                  'max-w-[260px] px-3 py-1.5 rounded shadow-lg bg-secondary-inverse text-secondary-inverse sm:max-w-sm z-10',
                   likeCount === 0 && 'hidden'
                 )}
               >


### PR DESCRIPTION
This ensures tooltips are shown visually above other content such as avatars.